### PR TITLE
fixed bug-initial-die-doesn't-match-initial-status-bar

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -49,7 +49,7 @@
      </size>
     </property>
     <property name="currentText">
-     <string>2</string>
+     <string>6</string>
     </property>
     <item>
      <property name="text">


### PR DESCRIPTION
changed the initial die to default to d6, as reflected in the initial status bar "1d6"